### PR TITLE
feat: Add Datadog APM monitoring integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'graphql'
 gem 'graphql-batch'
 gem 'bcrypt', '~> 3.1.7'
 gem 'rack-cors'
+gem 'datadog', require: 'ddtrace'
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,10 @@ gem 'graphql'
 gem 'graphql-batch'
 gem 'bcrypt', '~> 3.1.7'
 gem 'rack-cors'
-gem 'datadog', require: 'ddtrace'
+
+group :development, :production do
+  gem 'datadog', require: 'ddtrace'
+end
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,11 +101,20 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.5.1)
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
+    datadog (2.23.0)
+      cgi
+      datadog-ruby_core_source (~> 3.4, >= 3.4.2)
+      libdatadog (~> 24.0.1.1.0)
+      libddwaf (~> 1.30.0.0.0)
+      logger
+      msgpack
+    datadog-ruby_core_source (3.4.3)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -121,6 +130,9 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     fiber-storage (1.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -171,6 +183,15 @@ GEM
       actionmailer (>= 3.2)
       letter_opener (~> 1.0)
       railties (>= 3.2)
+    libdatadog (24.0.1.1.0)
+    libdatadog (24.0.1.1.0-aarch64-linux)
+    libdatadog (24.0.1.1.0-x86_64-linux)
+    libddwaf (1.30.0.0.0-aarch64-linux)
+      ffi (~> 1.0)
+    libddwaf (1.30.0.0.0-arm64-darwin)
+      ffi (~> 1.0)
+    libddwaf (1.30.0.0.0-x86_64-linux)
+      ffi (~> 1.0)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.0)
@@ -354,6 +375,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
   capybara
+  datadog
   debug
   error_highlight (>= 0.4.0)
   factory_bot_rails

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,4 +1,6 @@
-Datadog.configure do |c|
-  c.service = 'rails-blog'
-  c.env = 'dev'
+if defined?(Datadog)
+  Datadog.configure do |c|
+    c.service = 'rails-blog'
+    c.env = 'dev'
+  end
 end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,4 @@
+Datadog.configure do |c|
+  c.service = 'rails-blog'
+  c.env = 'dev'
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,17 @@ services:
     depends_on:
       - db
 
+  datadog-agent:
+    image: gcr.io/datadoghq/agent:7
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_SITE=ap1.datadoghq.com
+      - DD_ENV=dev
+      - DD_SERVICE=rails-blog
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+
 volumes:
   bundle_cache:


### PR DESCRIPTION
- Add ddtrace gem for application performance monitoring
- Configure Datadog agent container with API key and site settings
- Set environment to 'dev' and service name to 'rails-blog'
- Mount Docker socket and host metrics for container monitoring